### PR TITLE
Fixed problem with CV downloading

### DIFF
--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -72,7 +72,11 @@ var ErrInvalidParameter = errors.New("invalid parameter")
 func sendResponse(w http.ResponseWriter, resp interface{}, code int) {
 	w.WriteHeader(code)
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
+
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
`SetEscapeHTML` specifies whether problematic HTML characters should be escaped inside JSON quoted strings. The default behavior is to escape "&", "<", and ">" to "\u0026", "\u003c", and "\u003e" to avoid certain safety problems that can arise when embedding JSON in HTML.